### PR TITLE
Bug Fix

### DIFF
--- a/SwiftFilePath/Path.swift
+++ b/SwiftFilePath/Path.swift
@@ -12,7 +12,7 @@ public class Path {
     
     public class func isDir(path:NSString) -> Bool {
         var isDirectory: ObjCBool = false
-        let isFileExists = NSFileManager.defaultManager().fileExistsAtPath(path, isDirectory:&isDirectory)
+        let isFileExists = NSFileManager.defaultManager().fileExistsAtPath(path as String, isDirectory:&isDirectory)
         
         return isDirectory ? true : false
     }

--- a/SwiftFilePath/PathExtensionDir.swift
+++ b/SwiftFilePath/PathExtensionDir.swift
@@ -29,7 +29,7 @@ extension Path {
     }
     
     private class func userDomainOf(pathEnum:NSSearchPathDirectory)->Path{
-        let pathString = NSSearchPathForDirectoriesInDomains(pathEnum, .UserDomainMask, true)[0] as String
+        let pathString = NSSearchPathForDirectoriesInDomains(pathEnum, .UserDomainMask, true)[0] as! String
         return Path( pathString )
     }
     
@@ -54,7 +54,7 @@ extension Path: SequenceType {
         }
         
         return contents!.map({ [unowned self] content in
-            return self.content(content as String)
+            return self.content(content as! String)
         })
         
     }
@@ -64,7 +64,7 @@ extension Path: SequenceType {
     }
     
     public func content(path_string:NSString) -> Path {
-        return Path( self.path_string.stringByAppendingPathComponent(path_string) )
+        return Path( self.path_string.stringByAppendingPathComponent(path_string as String) )
     }
     
     public func child(path:NSString) -> Path {
@@ -88,7 +88,7 @@ extension Path: SequenceType {
         assert(self.isDir,"To get iterator, path must be dir< \(path_string) >")
         let iterator = fileManager.enumeratorAtPath(path_string)
         return GeneratorOf<Path>() {
-            let optionalContent = iterator?.nextObject() as String?
+            let optionalContent = iterator?.nextObject() as? String
             if var content = optionalContent {
                 return self.content(content)
             } else {

--- a/SwiftFilePathTests/SwiftFilePathTests.swift
+++ b/SwiftFilePathTests/SwiftFilePathTests.swift
@@ -16,7 +16,7 @@ extension String {
     func match(pattern: String) -> Bool {
         var error : NSError?
         let matcher = NSRegularExpression(pattern: pattern, options: nil, error: &error)
-        return matcher?.numberOfMatchesInString(self, options: nil, range: NSMakeRange(0, self.utf16Count)) != 0
+        return matcher?.numberOfMatchesInString(self, options: nil, range: NSMakeRange(0, count(self.utf16))) != 0
     }
     
 }


### PR DESCRIPTION
I solved `.contents` or `.children`
When I archived some project , `.contents` or `.children` were crashed.

I think `PathExtensionDir.swift` line 56
`return contents!.map({ [unowned self] content in` 
 to change↓
`return contents!.map({ content in`
