### PR TITLE
Add the build targets for Mac, tvOS and watchOS

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-SCHEME      = "SwiftFilePath"
+SCHEME      = "SwiftFilePath-iOS"
 DESTINATION = "name=iPhone 5,OS=8.1"
 
 desc "unit test"

--- a/SwiftFilePath.xcodeproj/project.pbxproj
+++ b/SwiftFilePath.xcodeproj/project.pbxproj
@@ -14,6 +14,25 @@
 		CCB3A04C1A6254910034E098 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04B1A6254910034E098 /* Path.swift */; };
 		CCB3A04F1A625A780034E098 /* PathExtensionDir.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04D1A625A780034E098 /* PathExtensionDir.swift */; };
 		CCB3A0501A625A780034E098 /* PathExtensionFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04E1A625A780034E098 /* PathExtensionFile.swift */; };
+		D63BC3A31C172BCD0071D0E2 /* SwiftFilePath.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D63BC3991C172BCD0071D0E2 /* SwiftFilePath.framework */; };
+		D63BC3CC1C172C740071D0E2 /* SwiftFilePath.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D63BC3C21C172C740071D0E2 /* SwiftFilePath.framework */; };
+		D63BC3D91C172D160071D0E2 /* SwiftFilePath.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7832F11A610124005E77C3 /* SwiftFilePath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D63BC3DA1C172D170071D0E2 /* SwiftFilePath.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7832F11A610124005E77C3 /* SwiftFilePath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D63BC3DB1C172D180071D0E2 /* SwiftFilePath.h in Headers */ = {isa = PBXBuildFile; fileRef = CC7832F11A610124005E77C3 /* SwiftFilePath.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D63BC3DC1C172D900071D0E2 /* PathExtensionDir.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04D1A625A780034E098 /* PathExtensionDir.swift */; };
+		D63BC3DD1C172D900071D0E2 /* PathExtensionFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04E1A625A780034E098 /* PathExtensionFile.swift */; };
+		D63BC3DE1C172D900071D0E2 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04B1A6254910034E098 /* Path.swift */; };
+		D63BC3DF1C172D900071D0E2 /* PathExtensionDir.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04D1A625A780034E098 /* PathExtensionDir.swift */; };
+		D63BC3E01C172D900071D0E2 /* PathExtensionFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04E1A625A780034E098 /* PathExtensionFile.swift */; };
+		D63BC3E11C172D900071D0E2 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04B1A6254910034E098 /* Path.swift */; };
+		D63BC3E21C172D910071D0E2 /* PathExtensionDir.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04D1A625A780034E098 /* PathExtensionDir.swift */; };
+		D63BC3E31C172D910071D0E2 /* PathExtensionFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04E1A625A780034E098 /* PathExtensionFile.swift */; };
+		D63BC3E41C172D910071D0E2 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB3A04B1A6254910034E098 /* Path.swift */; };
+		D63BC3E51C172D9E0071D0E2 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC78331D1A6186B7005E77C3 /* Result.swift */; };
+		D63BC3E61C172D9F0071D0E2 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC78331D1A6186B7005E77C3 /* Result.swift */; };
+		D63BC3E71C172DA00071D0E2 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC78331D1A6186B7005E77C3 /* Result.swift */; };
+		D63BC3E81C172DA50071D0E2 /* SwiftFilePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7832FE1A610125005E77C3 /* SwiftFilePathTests.swift */; };
+		D63BC3E91C172DA60071D0E2 /* SwiftFilePathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7832FE1A610125005E77C3 /* SwiftFilePathTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -24,19 +43,38 @@
 			remoteGlobalIDString = CC7832EB1A610124005E77C3;
 			remoteInfo = SwiftFilePath;
 		};
+		D63BC3A41C172BCD0071D0E2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CC7832E31A610124005E77C3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D63BC3981C172BCD0071D0E2;
+			remoteInfo = "SwiftFilePath-tvOS";
+		};
+		D63BC3CD1C172C740071D0E2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CC7832E31A610124005E77C3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D63BC3C11C172C740071D0E2;
+			remoteInfo = "SwiftFilePath-Mac";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		CC7832EC1A610124005E77C3 /* SwiftFilePath.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftFilePath.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC7832F01A610124005E77C3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CC7832F11A610124005E77C3 /* SwiftFilePath.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftFilePath.h; sourceTree = "<group>"; };
-		CC7832F71A610125005E77C3 /* SwiftFilePathTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftFilePathTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC7832F71A610125005E77C3 /* SwiftFilePath-iOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftFilePath-iOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC7832FD1A610125005E77C3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CC7832FE1A610125005E77C3 /* SwiftFilePathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFilePathTests.swift; sourceTree = "<group>"; };
 		CC78331D1A6186B7005E77C3 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		CCB3A04B1A6254910034E098 /* Path.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Path.swift; sourceTree = "<group>"; };
 		CCB3A04D1A625A780034E098 /* PathExtensionDir.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathExtensionDir.swift; sourceTree = "<group>"; };
 		CCB3A04E1A625A780034E098 /* PathExtensionFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathExtensionFile.swift; sourceTree = "<group>"; };
+		D63BC3991C172BCD0071D0E2 /* SwiftFilePath.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftFilePath.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D63BC3A21C172BCD0071D0E2 /* SwiftFilePath-tvOS Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftFilePath-tvOS Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D63BC3B51C172C540071D0E2 /* SwiftFilePath.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftFilePath.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D63BC3C21C172C740071D0E2 /* SwiftFilePath.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftFilePath.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D63BC3CB1C172C740071D0E2 /* SwiftFilePath-Mac Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SwiftFilePath-Mac Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,6 +90,43 @@
 			buildActionMask = 2147483647;
 			files = (
 				CC7832F81A610125005E77C3 /* SwiftFilePath.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3951C172BCD0071D0E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC39F1C172BCD0071D0E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D63BC3A31C172BCD0071D0E2 /* SwiftFilePath.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3B11C172C540071D0E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3BE1C172C740071D0E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3C81C172C740071D0E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D63BC3CC1C172C740071D0E2 /* SwiftFilePath.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -71,7 +146,12 @@
 			isa = PBXGroup;
 			children = (
 				CC7832EC1A610124005E77C3 /* SwiftFilePath.framework */,
-				CC7832F71A610125005E77C3 /* SwiftFilePathTests.xctest */,
+				CC7832F71A610125005E77C3 /* SwiftFilePath-iOS Tests.xctest */,
+				D63BC3991C172BCD0071D0E2 /* SwiftFilePath.framework */,
+				D63BC3A21C172BCD0071D0E2 /* SwiftFilePath-tvOS Tests.xctest */,
+				D63BC3B51C172C540071D0E2 /* SwiftFilePath.framework */,
+				D63BC3C21C172C740071D0E2 /* SwiftFilePath.framework */,
+				D63BC3CB1C172C740071D0E2 /* SwiftFilePath-Mac Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -125,12 +205,36 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D63BC3961C172BCD0071D0E2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D63BC3DA1C172D170071D0E2 /* SwiftFilePath.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3B21C172C540071D0E2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D63BC3DB1C172D180071D0E2 /* SwiftFilePath.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3BF1C172C740071D0E2 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D63BC3D91C172D160071D0E2 /* SwiftFilePath.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		CC7832EB1A610124005E77C3 /* SwiftFilePath */ = {
+		CC7832EB1A610124005E77C3 /* SwiftFilePath-iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CC7833021A610125005E77C3 /* Build configuration list for PBXNativeTarget "SwiftFilePath" */;
+			buildConfigurationList = CC7833021A610125005E77C3 /* Build configuration list for PBXNativeTarget "SwiftFilePath-iOS" */;
 			buildPhases = (
 				CC7832E71A610124005E77C3 /* Sources */,
 				CC7832E81A610124005E77C3 /* Frameworks */,
@@ -141,14 +245,14 @@
 			);
 			dependencies = (
 			);
-			name = SwiftFilePath;
+			name = "SwiftFilePath-iOS";
 			productName = SwiftFilePath;
 			productReference = CC7832EC1A610124005E77C3 /* SwiftFilePath.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		CC7832F61A610125005E77C3 /* SwiftFilePathTests */ = {
+		CC7832F61A610125005E77C3 /* SwiftFilePath-iOS Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CC7833051A610125005E77C3 /* Build configuration list for PBXNativeTarget "SwiftFilePathTests" */;
+			buildConfigurationList = CC7833051A610125005E77C3 /* Build configuration list for PBXNativeTarget "SwiftFilePath-iOS Tests" */;
 			buildPhases = (
 				CC7832F31A610125005E77C3 /* Sources */,
 				CC7832F41A610125005E77C3 /* Frameworks */,
@@ -159,9 +263,99 @@
 			dependencies = (
 				CC7832FA1A610125005E77C3 /* PBXTargetDependency */,
 			);
-			name = SwiftFilePathTests;
+			name = "SwiftFilePath-iOS Tests";
 			productName = SwiftFilePathTests;
-			productReference = CC7832F71A610125005E77C3 /* SwiftFilePathTests.xctest */;
+			productReference = CC7832F71A610125005E77C3 /* SwiftFilePath-iOS Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D63BC3981C172BCD0071D0E2 /* SwiftFilePath-tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D63BC3AA1C172BCD0071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-tvOS" */;
+			buildPhases = (
+				D63BC3941C172BCD0071D0E2 /* Sources */,
+				D63BC3951C172BCD0071D0E2 /* Frameworks */,
+				D63BC3961C172BCD0071D0E2 /* Headers */,
+				D63BC3971C172BCD0071D0E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SwiftFilePath-tvOS";
+			productName = "SwiftFilePath-tvOS";
+			productReference = D63BC3991C172BCD0071D0E2 /* SwiftFilePath.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D63BC3A11C172BCD0071D0E2 /* SwiftFilePath-tvOS Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D63BC3AD1C172BCD0071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-tvOS Tests" */;
+			buildPhases = (
+				D63BC39E1C172BCD0071D0E2 /* Sources */,
+				D63BC39F1C172BCD0071D0E2 /* Frameworks */,
+				D63BC3A01C172BCD0071D0E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D63BC3A51C172BCD0071D0E2 /* PBXTargetDependency */,
+			);
+			name = "SwiftFilePath-tvOS Tests";
+			productName = "SwiftFilePath-tvOSTests";
+			productReference = D63BC3A21C172BCD0071D0E2 /* SwiftFilePath-tvOS Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		D63BC3B41C172C540071D0E2 /* SwiftFilePath-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D63BC3BA1C172C540071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-watchOS" */;
+			buildPhases = (
+				D63BC3B01C172C540071D0E2 /* Sources */,
+				D63BC3B11C172C540071D0E2 /* Frameworks */,
+				D63BC3B21C172C540071D0E2 /* Headers */,
+				D63BC3B31C172C540071D0E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SwiftFilePath-watchOS";
+			productName = "SwiftFilePath-watchOS";
+			productReference = D63BC3B51C172C540071D0E2 /* SwiftFilePath.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D63BC3C11C172C740071D0E2 /* SwiftFilePath-Mac */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D63BC3D31C172C740071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-Mac" */;
+			buildPhases = (
+				D63BC3BD1C172C740071D0E2 /* Sources */,
+				D63BC3BE1C172C740071D0E2 /* Frameworks */,
+				D63BC3BF1C172C740071D0E2 /* Headers */,
+				D63BC3C01C172C740071D0E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SwiftFilePath-Mac";
+			productName = "SwiftFilePath-Mac";
+			productReference = D63BC3C21C172C740071D0E2 /* SwiftFilePath.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D63BC3CA1C172C740071D0E2 /* SwiftFilePath-Mac Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D63BC3D61C172C740071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-Mac Tests" */;
+			buildPhases = (
+				D63BC3C71C172C740071D0E2 /* Sources */,
+				D63BC3C81C172C740071D0E2 /* Frameworks */,
+				D63BC3C91C172C740071D0E2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D63BC3CE1C172C740071D0E2 /* PBXTargetDependency */,
+			);
+			name = "SwiftFilePath-Mac Tests";
+			productName = "SwiftFilePath-MacTests";
+			productReference = D63BC3CB1C172C740071D0E2 /* SwiftFilePath-Mac Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -171,7 +365,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Norihiro Sakamoto";
 				TargetAttributes = {
@@ -180,6 +374,21 @@
 					};
 					CC7832F61A610125005E77C3 = {
 						CreatedOnToolsVersion = 6.1;
+					};
+					D63BC3981C172BCD0071D0E2 = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
+					D63BC3A11C172BCD0071D0E2 = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
+					D63BC3B41C172C540071D0E2 = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
+					D63BC3C11C172C740071D0E2 = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
+					D63BC3CA1C172C740071D0E2 = {
+						CreatedOnToolsVersion = 7.1.1;
 					};
 				};
 			};
@@ -195,8 +404,13 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				CC7832EB1A610124005E77C3 /* SwiftFilePath */,
-				CC7832F61A610125005E77C3 /* SwiftFilePathTests */,
+				CC7832EB1A610124005E77C3 /* SwiftFilePath-iOS */,
+				D63BC3C11C172C740071D0E2 /* SwiftFilePath-Mac */,
+				D63BC3981C172BCD0071D0E2 /* SwiftFilePath-tvOS */,
+				D63BC3B41C172C540071D0E2 /* SwiftFilePath-watchOS */,
+				CC7832F61A610125005E77C3 /* SwiftFilePath-iOS Tests */,
+				D63BC3CA1C172C740071D0E2 /* SwiftFilePath-Mac Tests */,
+				D63BC3A11C172BCD0071D0E2 /* SwiftFilePath-tvOS Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -210,6 +424,41 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		CC7832F51A610125005E77C3 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3971C172BCD0071D0E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3A01C172BCD0071D0E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3B31C172C540071D0E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3C01C172C740071D0E2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3C91C172C740071D0E2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -238,13 +487,72 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D63BC3941C172BCD0071D0E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D63BC3E01C172D900071D0E2 /* PathExtensionFile.swift in Sources */,
+				D63BC3E11C172D900071D0E2 /* Path.swift in Sources */,
+				D63BC3E61C172D9F0071D0E2 /* Result.swift in Sources */,
+				D63BC3DF1C172D900071D0E2 /* PathExtensionDir.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC39E1C172BCD0071D0E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D63BC3E91C172DA60071D0E2 /* SwiftFilePathTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3B01C172C540071D0E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D63BC3E31C172D910071D0E2 /* PathExtensionFile.swift in Sources */,
+				D63BC3E41C172D910071D0E2 /* Path.swift in Sources */,
+				D63BC3E71C172DA00071D0E2 /* Result.swift in Sources */,
+				D63BC3E21C172D910071D0E2 /* PathExtensionDir.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3BD1C172C740071D0E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D63BC3DD1C172D900071D0E2 /* PathExtensionFile.swift in Sources */,
+				D63BC3DE1C172D900071D0E2 /* Path.swift in Sources */,
+				D63BC3E51C172D9E0071D0E2 /* Result.swift in Sources */,
+				D63BC3DC1C172D900071D0E2 /* PathExtensionDir.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D63BC3C71C172C740071D0E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D63BC3E81C172DA50071D0E2 /* SwiftFilePathTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		CC7832FA1A610125005E77C3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = CC7832EB1A610124005E77C3 /* SwiftFilePath */;
+			target = CC7832EB1A610124005E77C3 /* SwiftFilePath-iOS */;
 			targetProxy = CC7832F91A610125005E77C3 /* PBXContainerItemProxy */;
+		};
+		D63BC3A51C172BCD0071D0E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D63BC3981C172BCD0071D0E2 /* SwiftFilePath-tvOS */;
+			targetProxy = D63BC3A41C172BCD0071D0E2 /* PBXContainerItemProxy */;
+		};
+		D63BC3CE1C172C740071D0E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D63BC3C11C172C740071D0E2 /* SwiftFilePath-Mac */;
+			targetProxy = D63BC3CD1C172C740071D0E2 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -285,7 +593,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -325,7 +633,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -347,7 +655,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = SwiftFilePath;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -364,7 +672,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = SwiftFilePath;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -401,6 +709,201 @@
 			};
 			name = Release;
 		};
+		D63BC3AB1C172BCD0071D0E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftFilePath/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = SwiftFilePath;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		D63BC3AC1C172BCD0071D0E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftFilePath/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = SwiftFilePath;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		D63BC3AE1C172BCD0071D0E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftFilePathTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.SwiftFilePath-tvOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		D63BC3AF1C172BCD0071D0E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftFilePathTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.SwiftFilePath-tvOSTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		D63BC3BB1C172C540071D0E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftFilePath/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = SwiftFilePath;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		D63BC3BC1C172C540071D0E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftFilePath/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = SwiftFilePath;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		D63BC3D41C172C740071D0E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftFilePath/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = SwiftFilePath;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		D63BC3D51C172C740071D0E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftFilePath/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = SwiftFilePath;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		D63BC3D71C172C740071D0E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftFilePathTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.SwiftFilePath-MacTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		D63BC3D81C172C740071D0E2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SwiftFilePathTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.SwiftFilePath-MacTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -413,7 +916,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CC7833021A610125005E77C3 /* Build configuration list for PBXNativeTarget "SwiftFilePath" */ = {
+		CC7833021A610125005E77C3 /* Build configuration list for PBXNativeTarget "SwiftFilePath-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				CC7833031A610125005E77C3 /* Debug */,
@@ -422,7 +925,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CC7833051A610125005E77C3 /* Build configuration list for PBXNativeTarget "SwiftFilePathTests" */ = {
+		CC7833051A610125005E77C3 /* Build configuration list for PBXNativeTarget "SwiftFilePath-iOS Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				CC7833061A610125005E77C3 /* Debug */,
@@ -430,6 +933,46 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		D63BC3AA1C172BCD0071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D63BC3AB1C172BCD0071D0E2 /* Debug */,
+				D63BC3AC1C172BCD0071D0E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		D63BC3AD1C172BCD0071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-tvOS Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D63BC3AE1C172BCD0071D0E2 /* Debug */,
+				D63BC3AF1C172BCD0071D0E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		D63BC3BA1C172C540071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D63BC3BB1C172C540071D0E2 /* Debug */,
+				D63BC3BC1C172C540071D0E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		D63BC3D31C172C740071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-Mac" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D63BC3D41C172C740071D0E2 /* Debug */,
+				D63BC3D51C172C740071D0E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		D63BC3D61C172C740071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-Mac Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D63BC3D71C172C740071D0E2 /* Debug */,
+				D63BC3D81C172C740071D0E2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-Mac.xcscheme
+++ b/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-Mac.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D63BC3C11C172C740071D0E2"
+               BuildableName = "SwiftFilePath.framework"
+               BlueprintName = "SwiftFilePath-Mac"
+               ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D63BC3CA1C172C740071D0E2"
+               BuildableName = "SwiftFilePath-Mac Tests.xctest"
+               BlueprintName = "SwiftFilePath-Mac Tests"
+               ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D63BC3C11C172C740071D0E2"
+            BuildableName = "SwiftFilePath.framework"
+            BlueprintName = "SwiftFilePath-Mac"
+            ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D63BC3C11C172C740071D0E2"
+            BuildableName = "SwiftFilePath.framework"
+            BlueprintName = "SwiftFilePath-Mac"
+            ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D63BC3C11C172C740071D0E2"
+            BuildableName = "SwiftFilePath.framework"
+            BlueprintName = "SwiftFilePath-Mac"
+            ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-iOS.xcscheme
+++ b/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -16,21 +16,7 @@
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CC7832EB1A610124005E77C3"
                BuildableName = "SwiftFilePath.framework"
-               BlueprintName = "SwiftFilePath"
-               ReferencedContainer = "container:SwiftFilePath.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CC7832F61A610125005E77C3"
-               BuildableName = "SwiftFilePathTests.xctest"
-               BlueprintName = "SwiftFilePathTests"
+               BlueprintName = "SwiftFilePath-iOS"
                ReferencedContainer = "container:SwiftFilePath.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -47,8 +33,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CC7832F61A610125005E77C3"
-               BuildableName = "SwiftFilePathTests.xctest"
-               BlueprintName = "SwiftFilePathTests"
+               BuildableName = "SwiftFilePath-iOS Tests.xctest"
+               BlueprintName = "SwiftFilePath-iOS Tests"
                ReferencedContainer = "container:SwiftFilePath.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -58,7 +44,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CC7832EB1A610124005E77C3"
             BuildableName = "SwiftFilePath.framework"
-            BlueprintName = "SwiftFilePath"
+            BlueprintName = "SwiftFilePath-iOS"
             ReferencedContainer = "container:SwiftFilePath.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -80,7 +66,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CC7832EB1A610124005E77C3"
             BuildableName = "SwiftFilePath.framework"
-            BlueprintName = "SwiftFilePath"
+            BlueprintName = "SwiftFilePath-iOS"
             ReferencedContainer = "container:SwiftFilePath.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -98,7 +84,7 @@
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "CC7832EB1A610124005E77C3"
             BuildableName = "SwiftFilePath.framework"
-            BlueprintName = "SwiftFilePath"
+            BlueprintName = "SwiftFilePath-iOS"
             ReferencedContainer = "container:SwiftFilePath.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-tvOS.xcscheme
+++ b/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-tvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D63BC3981C172BCD0071D0E2"
+               BuildableName = "SwiftFilePath.framework"
+               BlueprintName = "SwiftFilePath-tvOS"
+               ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D63BC3A11C172BCD0071D0E2"
+               BuildableName = "SwiftFilePath-tvOS Tests.xctest"
+               BlueprintName = "SwiftFilePath-tvOS Tests"
+               ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D63BC3981C172BCD0071D0E2"
+            BuildableName = "SwiftFilePath.framework"
+            BlueprintName = "SwiftFilePath-tvOS"
+            ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D63BC3981C172BCD0071D0E2"
+            BuildableName = "SwiftFilePath.framework"
+            BlueprintName = "SwiftFilePath-tvOS"
+            ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D63BC3981C172BCD0071D0E2"
+            BuildableName = "SwiftFilePath.framework"
+            BlueprintName = "SwiftFilePath-tvOS"
+            ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-watchOS.xcscheme
+++ b/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-watchOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D63BC3B41C172C540071D0E2"
+               BuildableName = "SwiftFilePath.framework"
+               BlueprintName = "SwiftFilePath-watchOS"
+               ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D63BC3B41C172C540071D0E2"
+            BuildableName = "SwiftFilePath.framework"
+            BlueprintName = "SwiftFilePath-watchOS"
+            ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D63BC3B41C172C540071D0E2"
+            BuildableName = "SwiftFilePath.framework"
+            BlueprintName = "SwiftFilePath-watchOS"
+            ReferencedContainer = "container:SwiftFilePath.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftFilePath/Info.plist
+++ b/SwiftFilePath/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.4</string>
+	<string>0.0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SwiftFilePath/SwiftFilePath.h
+++ b/SwiftFilePath/SwiftFilePath.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015年 Norihiro Sakamoto. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for SwiftFilePath.
 FOUNDATION_EXPORT double SwiftFilePathVersionNumber;

--- a/SwiftFilePathTests/SwiftFilePathTests.swift
+++ b/SwiftFilePathTests/SwiftFilePathTests.swift
@@ -29,7 +29,11 @@ extension String {
 
 class SwiftFilePathTests: XCTestCase {
     
+    #if os(iOS)
     let sandboxDir = Path.temporaryDir.content("sandbox")
+    #else
+    let sandboxDir = Path("data/tmp/sandbox")
+    #endif
     
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
I added the build targets for Mac, tvOS and watchOS. I also added the tests for them.

When I tried to use _SwiftFilePath_ for a Mac app, it couldn't be built using _Carthage_. I checked the project and found there were no targets besides the one for iOS. So I added the build targets.

Because I didn't know how you wanted to update/maintain the .travis.yaml and the Rakefile, I didn't update them for the new 3 build targets. I just updated the scheme name for iOS in the Rakefile.
