### PR TITLE
Update swift3 xcode8

### DIFF
--- a/SwiftFilePath.xcodeproj/project.pbxproj
+++ b/SwiftFilePath.xcodeproj/project.pbxproj
@@ -366,29 +366,37 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Norihiro Sakamoto";
 				TargetAttributes = {
 					CC7832EB1A610124005E77C3 = {
 						CreatedOnToolsVersion = 6.1;
+						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 					CC7832F61A610125005E77C3 = {
 						CreatedOnToolsVersion = 6.1;
+						LastSwiftMigration = 0800;
 					};
 					D63BC3981C172BCD0071D0E2 = {
 						CreatedOnToolsVersion = 7.1.1;
+						LastSwiftMigration = 0800;
 					};
 					D63BC3A11C172BCD0071D0E2 = {
 						CreatedOnToolsVersion = 7.1.1;
+						LastSwiftMigration = 0800;
 					};
 					D63BC3B41C172C540071D0E2 = {
 						CreatedOnToolsVersion = 7.1.1;
+						LastSwiftMigration = 0800;
 					};
 					D63BC3C11C172C740071D0E2 = {
 						CreatedOnToolsVersion = 7.1.1;
+						LastSwiftMigration = 0800;
 					};
 					D63BC3CA1C172C740071D0E2 = {
 						CreatedOnToolsVersion = 7.1.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -570,8 +578,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -581,6 +591,7 @@
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -617,8 +628,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -627,6 +640,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -636,6 +650,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -657,6 +672,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftFilePath;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -664,7 +680,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -674,6 +692,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SwiftFilePath;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -692,6 +711,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -706,12 +726,14 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
 		D63BC3AB1C172BCD0071D0E2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -725,6 +747,7 @@
 				PRODUCT_NAME = SwiftFilePath;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -733,6 +756,7 @@
 		D63BC3AC1C172BCD0071D0E2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -747,6 +771,7 @@
 				PRODUCT_NAME = SwiftFilePath;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
@@ -762,6 +787,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.SwiftFilePath-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -777,6 +803,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.SwiftFilePath-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
@@ -785,6 +812,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -798,6 +826,7 @@
 				PRODUCT_NAME = SwiftFilePath;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -807,6 +836,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -821,6 +851,7 @@
 				PRODUCT_NAME = SwiftFilePath;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -845,6 +876,7 @@
 				PRODUCT_NAME = SwiftFilePath;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -868,6 +900,7 @@
 				PRODUCT_NAME = SwiftFilePath;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -884,6 +917,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.SwiftFilePath-MacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -901,6 +935,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "me.nori0620.SwiftFilePath-MacTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -941,6 +976,7 @@
 				D63BC3AC1C172BCD0071D0E2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		D63BC3AD1C172BCD0071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-tvOS Tests" */ = {
 			isa = XCConfigurationList;
@@ -949,6 +985,7 @@
 				D63BC3AF1C172BCD0071D0E2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		D63BC3BA1C172C540071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-watchOS" */ = {
 			isa = XCConfigurationList;
@@ -957,6 +994,7 @@
 				D63BC3BC1C172C540071D0E2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		D63BC3D31C172C740071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-Mac" */ = {
 			isa = XCConfigurationList;
@@ -965,6 +1003,7 @@
 				D63BC3D51C172C740071D0E2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		D63BC3D61C172C740071D0E2 /* Build configuration list for PBXNativeTarget "SwiftFilePath-Mac Tests" */ = {
 			isa = XCConfigurationList;
@@ -973,6 +1012,7 @@
 				D63BC3D81C172C740071D0E2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-Mac.xcscheme
+++ b/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-iOS.xcscheme
+++ b/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-tvOS.xcscheme
+++ b/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-watchOS.xcscheme
+++ b/SwiftFilePath.xcodeproj/xcshareddata/xcschemes/SwiftFilePath-watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/SwiftFilePath/Path.swift
+++ b/SwiftFilePath/Path.swift
@@ -6,20 +6,20 @@
 //  Copyright (c) 2015年 Norihiro Sakamoto. All rights reserved.
 //
 
-public class Path {
+open class Path {
     
     // MARK: - Class methods
     
-    public class func isDir(path:NSString) -> Bool {
+    open class func isDir(_ path:NSString) -> Bool {
         var isDirectory: ObjCBool = false
-        NSFileManager.defaultManager().fileExistsAtPath(path as String, isDirectory:&isDirectory)
-        return isDirectory ? true : false
+        FileManager.default.fileExists(atPath: path as String, isDirectory:&isDirectory)
+        return isDirectory.boolValue ? true : false
     }
     
     // MARK: - Instance properties and initializer
     
-    lazy var fileManager = NSFileManager.defaultManager()
-    public let path_string:String
+    lazy var fileManager = FileManager.default
+    open let path_string:String
     
     
     public init(_ p: String) {
@@ -28,42 +28,42 @@ public class Path {
     
     // MARK: - Instance val
     
-    public var attributes:NSDictionary?{
+    open var attributes:NSDictionary?{
         get { return self.loadAttributes() }
     }
     
-    public var asString: String {
+    open var asString: String {
         return path_string
     }
     
-    public var exists: Bool {
-        return fileManager.fileExistsAtPath(path_string)
+    open var exists: Bool {
+        return fileManager.fileExists(atPath: path_string)
     }
     
-    public var isDir: Bool {
-        return Path.isDir(path_string);
+    open var isDir: Bool {
+        return Path.isDir(path_string as NSString);
     }
     
-    public var basename:NSString {
-        return ( path_string as NSString ).lastPathComponent
+    open var basename:NSString {
+        return ( path_string as NSString ).lastPathComponent as NSString
     }
     
-    public var parent: Path{
-        return Path( (path_string as NSString ).stringByDeletingLastPathComponent )
+    open var parent: Path{
+        return Path( (path_string as NSString ).deletingLastPathComponent )
     }
     
     // MARK: - Instance methods
     
-    public func toString() -> String {
+    open func toString() -> String {
         return path_string
     }
     
-    public func remove() -> Result<Path,NSError> {
+    @discardableResult open func remove() -> Result<Path,NSError> {
         assert(self.exists,"To remove file, file MUST be exists")
         var error: NSError?
         let result: Bool
         do {
-            try fileManager.removeItemAtPath(path_string)
+            try fileManager.removeItem(atPath: path_string)
             result = true
         } catch let error1 as NSError {
             error = error1
@@ -74,12 +74,12 @@ public class Path {
             : Result(failure: error!);
     }
     
-    public func copyTo(toPath:Path) -> Result<Path,NSError> {
+    @discardableResult open func copyTo(_ toPath:Path) -> Result<Path,NSError> {
         assert(self.exists,"To copy file, file MUST be exists")
         var error: NSError?
         let result: Bool
         do {
-            try fileManager.copyItemAtPath(path_string,
+            try fileManager.copyItem(atPath: path_string,
                         toPath: toPath.toString())
             result = true
         } catch let error1 as NSError {
@@ -91,12 +91,12 @@ public class Path {
             : Result(failure: error!)
     }
     
-    public func moveTo(toPath:Path) -> Result<Path,NSError> {
+    @discardableResult open func moveTo(_ toPath:Path) -> Result<Path,NSError> {
         assert(self.exists,"To move file, file MUST be exists")
         var error: NSError?
         let result: Bool
         do {
-            try fileManager.moveItemAtPath(path_string,
+            try fileManager.moveItem(atPath: path_string,
                         toPath: toPath.toString())
             result = true
         } catch let error1 as NSError {
@@ -108,12 +108,12 @@ public class Path {
             : Result(failure: error!)
     }
     
-    private func loadAttributes() -> NSDictionary? {
+    fileprivate func loadAttributes() -> NSDictionary? {
         assert(self.exists,"File must be exists to load file.< \(path_string) >")
         var loadError: NSError?
         let result: [NSObject: AnyObject]?
         do {
-            result = try self.fileManager.attributesOfItemAtPath(path_string)
+            result = try self.fileManager.attributesOfItem(atPath: path_string)
         } catch let error as NSError {
             loadError = error
             result = nil
@@ -123,7 +123,7 @@ public class Path {
             print("Error< \(error.localizedDescription) >")
         }
         
-        return result
+        return result as NSDictionary?
     }
     
 }
@@ -132,7 +132,7 @@ public class Path {
 
 extension Path:  CustomStringConvertible {
     public var description: String {
-        return "\(NSStringFromClass(self.dynamicType))<path:\(path_string)>"
+        return "\(NSStringFromClass(type(of: self)))<path:\(path_string)>"
     }
 }
 

--- a/SwiftFilePath/Path.swift
+++ b/SwiftFilePath/Path.swift
@@ -111,7 +111,7 @@ open class Path {
     fileprivate func loadAttributes() -> NSDictionary? {
         assert(self.exists,"File must be exists to load file.< \(path_string) >")
         var loadError: NSError?
-        let result: [NSObject: AnyObject]?
+        let result: [FileAttributeKey : Any]?
         do {
             result = try self.fileManager.attributesOfItem(atPath: path_string)
         } catch let error as NSError {

--- a/SwiftFilePath/PathExtensionDir.swift
+++ b/SwiftFilePath/PathExtensionDir.swift
@@ -21,15 +21,15 @@ extension Path {
     }
     
     public class var documentsDir:Path {
-        return Path.userDomainOf(.DocumentDirectory)
+        return Path.userDomainOf(.documentDirectory)
     }
     
     public class var cacheDir:Path {
-        return Path.userDomainOf(.CachesDirectory)
+        return Path.userDomainOf(.cachesDirectory)
     }
     
-    private class func userDomainOf(pathEnum:NSSearchPathDirectory)->Path{
-        let pathString = NSSearchPathForDirectoriesInDomains(pathEnum, .UserDomainMask, true)[0] 
+    fileprivate class func userDomainOf(_ pathEnum:FileManager.SearchPathDirectory)->Path{
+        let pathString = NSSearchPathForDirectoriesInDomains(pathEnum, .userDomainMask, true)[0] 
         return Path( pathString )
     }
     
@@ -37,10 +37,10 @@ extension Path {
 #endif
 
 // Add Dir Behavior to Path by extension
-extension Path: SequenceType {
+extension Path: Sequence {
     
     public subscript(filename: String) -> Path{
-        get { return self.content(filename) }
+        get { return self.content(filename as NSString) }
     }
 
     public var children:Array<Path>? {
@@ -49,8 +49,8 @@ extension Path: SequenceType {
         var loadError: NSError?
         let contents: [AnyObject]?
         do {
-            contents = try self.fileManager.contentsOfDirectoryAtPath(path_string
-                        )
+            contents = try self.fileManager.contentsOfDirectory(atPath: path_string
+                        ) as [AnyObject]?
         } catch let error as NSError {
             loadError = error
             contents = nil
@@ -60,7 +60,7 @@ extension Path: SequenceType {
         }
         
         return contents!.map({ [unowned self] content in
-            return self.content(content as! String)
+            return self.content(content as! String as NSString)
         })
         
     }
@@ -69,23 +69,23 @@ extension Path: SequenceType {
         return self.children
     }
     
-    public func content(path_string:NSString) -> Path {
+    public func content(_ path_string:NSString) -> Path {
         return Path(
-            NSURL(fileURLWithPath: self.path_string)
-                .URLByAppendingPathComponent( path_string as String )
-                .path!
+            URL(fileURLWithPath: self.path_string)
+                .appendingPathComponent( path_string as String )
+                .path
         )
     }
     
-    public func child(path:NSString) -> Path {
+    public func child(_ path:NSString) -> Path {
         return self.content(path)
     }
     
-    public func mkdir() -> Result<Path,NSError> {
+    @discardableResult public func mkdir() -> Result<Path,NSError> {
         var error: NSError?
         let result: Bool
         do {
-            try fileManager.createDirectoryAtPath(path_string,
+            try fileManager.createDirectory(atPath: path_string,
                         withIntermediateDirectories:true,
                             attributes:nil)
             result = true
@@ -99,15 +99,15 @@ extension Path: SequenceType {
         
     }
     
-    public func generate() -> AnyGenerator<Path> {
+    public func makeIterator() -> AnyIterator<Path> {
         assert(self.isDir,"To get iterator, path must be dir< \(path_string) >")
-        let iterator = fileManager.enumeratorAtPath(path_string)
-        return anyGenerator() {
+        let iterator = fileManager.enumerator(atPath: path_string)
+        return AnyIterator() {
             let optionalContent = iterator?.nextObject() as! String?
             if let content = optionalContent {
-                return self.content(content)
+                return self.content(content as NSString)
             } else {
-                return .None
+                return .none
             }
         }
     }

--- a/SwiftFilePath/PathExtensionFile.swift
+++ b/SwiftFilePath/PathExtensionFile.swift
@@ -62,7 +62,7 @@ extension  Path {
         return read
     }
     
-    public func writeString(_ string:String) -> Result<Path,NSError> {
+    @discardableResult public func writeString(_ string:String) -> Result<Path,NSError> {
         assert(!self.isDir,"Can NOT write data from  dir")
         var error: NSError?
         let result: Bool
@@ -87,7 +87,7 @@ extension  Path {
         return (try? Data(contentsOf: URL(fileURLWithPath: path_string)))
     }
     
-    public func writeData(_ data:Data) -> Result<Path,NSError> {
+    @discardableResult public func writeData(_ data:Data) -> Result<Path,NSError> {
         assert(!self.isDir,"Can NOT write data from  dir")
         var error: NSError?
         let result: Bool

--- a/SwiftFilePath/PathExtensionFile.swift
+++ b/SwiftFilePath/PathExtensionFile.swift
@@ -10,22 +10,22 @@
 extension  Path {
     
     public var ext:NSString {
-        return NSURL(fileURLWithPath:path_string).pathExtension!
+        return URL(fileURLWithPath:path_string).pathExtension as NSString
     }
     
-    public func touch() -> Result<Path,NSError> {
+    @discardableResult public func touch() -> Result<Path,NSError> {
         assert(!self.isDir,"Can NOT touch to dir")
         return self.exists
             ? self.updateModificationDate()
             : self.createEmptyFile()
     }
     
-    public func updateModificationDate(date: NSDate = NSDate() ) -> Result<Path,NSError>{
+    @discardableResult public func updateModificationDate(_ date: Date = Date() ) -> Result<Path,NSError>{
         var error: NSError?
         let result: Bool
         do {
             try fileManager.setAttributes(
-                        [NSFileModificationDate :date],
+                        [FileAttributeKey.modificationDate :date],
                         ofItemAtPath:path_string)
             result = true
         } catch let error1 as NSError {
@@ -37,7 +37,7 @@ extension  Path {
             : Result(failure: error!)
     }
     
-    private func createEmptyFile() -> Result<Path,NSError>{
+    @discardableResult fileprivate func createEmptyFile() -> Result<Path,NSError>{
         return self.writeString("")
     }
     
@@ -49,7 +49,7 @@ extension  Path {
         let read: String?
         do {
             read = try String(contentsOfFile: path_string,
-                                            encoding: NSUTF8StringEncoding)
+                                            encoding: String.Encoding.utf8)
         } catch let error as NSError {
             readError = error
             read = nil
@@ -62,14 +62,14 @@ extension  Path {
         return read
     }
     
-    public func writeString(string:String) -> Result<Path,NSError> {
+    public func writeString(_ string:String) -> Result<Path,NSError> {
         assert(!self.isDir,"Can NOT write data from  dir")
         var error: NSError?
         let result: Bool
         do {
-            try string.writeToFile(path_string,
+            try string.write(toFile: path_string,
                         atomically:true,
-                        encoding: NSUTF8StringEncoding)
+                        encoding: String.Encoding.utf8)
             result = true
         } catch let error1 as NSError {
             error = error1
@@ -82,17 +82,17 @@ extension  Path {
     
     // MARK: - read/write NSData
     
-    public func readData() -> NSData? {
+    public func readData() -> Data? {
         assert(!self.isDir,"Can NOT read data from  dir")
-        return NSData(contentsOfFile: path_string)
+        return (try? Data(contentsOf: URL(fileURLWithPath: path_string)))
     }
     
-    public func writeData(data:NSData) -> Result<Path,NSError> {
+    public func writeData(_ data:Data) -> Result<Path,NSError> {
         assert(!self.isDir,"Can NOT write data from  dir")
         var error: NSError?
         let result: Bool
         do {
-            try data.writeToFile(path_string, options:.DataWritingAtomic)
+            try data.write(to: URL(fileURLWithPath: path_string), options:.atomic)
             result = true
         } catch let error1 as NSError {
             error = error1

--- a/SwiftFilePath/Result.swift
+++ b/SwiftFilePath/Result.swift
@@ -8,66 +8,66 @@
 
 public enum Result<S,F> {
     
-    case Success(S)
-    case Failure(F)
+    case success(S)
+    case failure(F)
     
     public init(success:S){
-        self = .Success(success)
+        self = .success(success)
     }
     
     public init(failure:F){
-        self = .Failure(failure)
+        self = .failure(failure)
     }
     
     public var isSuccess:Bool {
         switch self {
-            case .Success: return true
-            case .Failure: return false
+            case .success: return true
+            case .failure: return false
         }
         
     }
     
     public var isFailure:Bool {
         switch self {
-            case .Success: return false
-            case .Failure: return true
+            case .success: return false
+            case .failure: return true
         }
     }
     
     public var value:S? {
         switch self {
-        case .Success(let success):
+        case .success(let success):
             return success
-        case .Failure(_):
-            return .None
+        case .failure(_):
+            return .none
         }
     }
     
     public var error:F? {
         switch self {
-        case .Success(_):
-            return .None
-        case .Failure(let error):
+        case .success(_):
+            return .none
+        case .failure(let error):
             return error
         }
     }
     
-    public func onFailure(handler:(F) -> Void ) -> Result<S,F> {
+    public func onFailure(_ handler:(F) -> Void ) -> Result<S,F> {
         switch self {
-        case .Success(_):
+        case .success(_):
             return self
-        case .Failure(let error):
+        case .failure(let error):
             handler( error )
             return self
         }
     }
     
-    public func onSuccess(handler:(S) -> Void ) -> Result<S,F> {
+    public func onSuccess(_ handler:(S) -> Void ) -> Result<S,F> {
         switch self {
-        case .Success(let success):
+        case .success(let success):
             handler(success )
             return self
-        case .Failure(_):
+        case .failure(_):
             return self
         }
     }

--- a/SwiftFilePathTests/SwiftFilePathTests.swift
+++ b/SwiftFilePathTests/SwiftFilePathTests.swift
@@ -13,14 +13,14 @@ import SwiftFilePath
 
 extension String {
     
-    func match(pattern: String) -> Bool {
+    func match(_ pattern: String) -> Bool {
         let matcher: NSRegularExpression?
         do {
             matcher = try NSRegularExpression(pattern: pattern, options: [])
         } catch _ as NSError {
             matcher = nil
         }
-        return matcher?.numberOfMatchesInString(self, options: [], range: NSMakeRange(0, self.utf16.count)) != 0
+        return matcher?.numberOfMatches(in: self, options: [], range: NSMakeRange(0, self.utf16.count)) != 0
     }
     
 }
@@ -45,7 +45,7 @@ class SwiftFilePathTests: XCTestCase {
         self.sandboxDir.remove()
     }
     
-    func locally(x: () -> ()) {
+    func locally(_ x: () -> ()) {
         x()
     }
     
@@ -257,8 +257,8 @@ class SwiftFilePathTests: XCTestCase {
         
         for content in sandboxDir {
             XCTAssertTrue(content.exists)
-            contentCount++
-            if( content.isDir ){ dirCount++ }
+            contentCount += 1
+            if( content.isDir ){ dirCount += 1 }
         }
         XCTAssertEqual( contentCount, 3)
         XCTAssertEqual( dirCount, 1)
@@ -300,31 +300,33 @@ class SwiftFilePathTests: XCTestCase {
         
         locally {
             let string  = "HelloData"
-            let data    = string.dataUsingEncoding(NSUTF8StringEncoding)
+            let data    = string.data(using: String.Encoding.utf8)
             let result = binFile.writeData( data! )
             XCTAssertTrue( result.isSuccess )
             
             let readData = binFile.readData()
-            let readString = NSString(data: readData!, encoding: NSUTF8StringEncoding)!
+            let readString = NSString(data: readData!, encoding: String.Encoding.utf8.rawValue)!
             XCTAssertEqual( readString, "HelloData")
         }
         
         locally {
             let string  = "HelloData Again"
-            let data    = string.dataUsingEncoding(NSUTF8StringEncoding)
+            let data    = string.data(using: String.Encoding.utf8)
             let result = binFile.writeData( data! )
             XCTAssertTrue( result.isSuccess )
             
             let readData = binFile.readData()
-            let readString = NSString(data: readData!, encoding: NSUTF8StringEncoding)!
+            let readString = NSString(data: readData!, encoding: String.Encoding.utf8.rawValue)!
             XCTAssertEqual( readString, "HelloData Again")
         }
         
         locally {
             binFile.remove()
-            let empty = NSData()
-            let readData = binFile.readData() ?? empty
-            XCTAssertEqual( readData, empty )
+            let empty = Data()
+            let readData = binFile.readData() ??
+            
+            empty as Data
+            XCTAssertEqual( readData, empty as Data )
         }
     }
     
@@ -431,10 +433,10 @@ class SwiftFilePathTests: XCTestCase {
             let result = Result<Int,String>(success:200);
             
             switch result {
-                case .Success(let value):
+                case .success(let value):
                     callOnSuccess = true
                     print(value)
-                case .Failure(let error):
+                case .failure(let error):
                     callOnFailure = true
                     print(error)
             }
@@ -448,10 +450,10 @@ class SwiftFilePathTests: XCTestCase {
             let result = Result<Int,String>(failure: "ERROR!!!");
             
             switch result {
-                case .Success(let value):
+                case .success(let value):
                     callOnSuccess = true
                     print(value)
-                case .Failure(let error):
+                case .failure(let error):
                     callOnFailure = true
                     print(error)
             }


### PR DESCRIPTION
## Support Swift3.0 in Xcode8
- Every test in every device( iOS, appleTV, watchOS, Mac) is passed ;)
- Almost change is by Xcode [Edit -> Convert]
- I change some sowing below
## Place where I changed
- add  @discardableResult to seems need to avoid warning
- make test pass with 0b95d52 
- change form {++} to  {+= 1 } in test code
